### PR TITLE
change width of logo

### DIFF
--- a/_sass/custom/_nav.scss
+++ b/_sass/custom/_nav.scss
@@ -62,6 +62,7 @@ nav#main-nav {
       // left: 15px;      
       display:inline-block;
       height:60px;
+      width:150px;
     }
 
     .nav-home-brand #logo g,


### PR DESCRIPTION
This is an attempt to solve #3.
It works up to a browser size of >250px (on Desktop and Mobile), now. For smaller resolutions  the menu drops in the next line. This is an overall issue of the ppsn template. Solution might be to set an overall minimal page width of 250px.